### PR TITLE
Grafana 用イメージ作成のための Dockerfile を追加する

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ up:
 	docker compose up -d
 
 down:
-	docker compose down
+	docker compose down --rmi local
 	sudo rm -rf ./ingester/.venv
 
 clean:

--- a/compose.yml
+++ b/compose.yml
@@ -53,7 +53,9 @@ services:
 
   # motherduck-duckdb-datasource は./plugins に展開済みの想定
   grafana:
-    image: grafana/grafana:latest-ubuntu
+    build:
+      context: ./grafana
+      dockerfile: Dockerfile
     container_name: grafana
     ports:
       - 3000:3000
@@ -62,7 +64,6 @@ services:
     environment:
       - GF_LOG_MODE=console
       - GF_PATHS_DATA=/var/lib/grafana
-      - GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS=motherduck-duckdb-datasource
       - GF_SECURITY_ADMIN_USER=${GF_SECURITY_ADMIN_USER}
       - GF_SECURITY_ADMIN_PASSWORD=${GF_SECURITY_ADMIN_PASSWORD}
     depends_on:

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -76,6 +76,8 @@ make up
 
 Fluent Bit, MinIO, Grafana の Docker コンテナを削除します
 
+make down 時には、make up 時に作成した Grafana 用の Docker イメージも削除します
+
 ```bash
 make down
 ```

--- a/grafana/Dockerfile
+++ b/grafana/Dockerfile
@@ -14,6 +14,8 @@ RUN <<EOF
   wget -q -O - https://apt.grafana.com/gpg.key | gpg --dearmor | tee /etc/apt/keyrings/grafana.gpg > /dev/null
   echo "deb [signed-by=/etc/apt/keyrings/grafana.gpg] https://apt.grafana.com stable main" | tee -a /etc/apt/sources.list.d/grafana.list
   apt-get update && apt-get -y install grafana
+  apt-get clean
+  rm -rf /var/lib/apt/lists/*
 EOF
 
 USER grafana

--- a/grafana/Dockerfile
+++ b/grafana/Dockerfile
@@ -8,18 +8,13 @@ ENV GF_CONFIG=/etc/grafana/grafana.ini
 ENV GF_PATHS_PLUGINS=/var/lib/grafana/plugins
 ENV GF_PATHS_PROVISIONING=/etc/grafana/provisioning
 
-ENV GF_SECURITY_ADMIN_USER
-ENV GF_SECURITY_ADMIN_PASSWORD
-
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y apt-transport-https software-properties-common wget
-
-RUN mkdir -p /etc/apt/keyrings/
-
-RUN wget -q -O - https://apt.grafana.com/gpg.key | gpg --dearmor | tee /etc/apt/keyrings/grafana.gpg > /dev/null
-
-RUN echo "deb [signed-by=/etc/apt/keyrings/grafana.gpg] https://apt.grafana.com stable main" | tee -a /etc/apt/sources.list.d/grafana.list
-
-RUN apt-get update && apt-get -y install grafana
+RUN <<EOF
+  apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y apt-transport-https software-properties-common wget
+  mkdir -p /etc/apt/keyrings/
+  wget -q -O - https://apt.grafana.com/gpg.key | gpg --dearmor | tee /etc/apt/keyrings/grafana.gpg > /dev/null
+  echo "deb [signed-by=/etc/apt/keyrings/grafana.gpg] https://apt.grafana.com stable main" | tee -a /etc/apt/sources.list.d/grafana.list
+  apt-get update && apt-get -y install grafana
+EOF
 
 USER grafana
 

--- a/grafana/Dockerfile
+++ b/grafana/Dockerfile
@@ -9,7 +9,7 @@ ENV GF_PATHS_PLUGINS=/var/lib/grafana/plugins
 ENV GF_PATHS_PROVISIONING=/etc/grafana/provisioning
 
 RUN <<EOF
-  apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y apt-transport-https software-properties-common wget
+  apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends apt-transport-https software-properties-common wget
   mkdir -p /etc/apt/keyrings/
   wget -q -O - https://apt.grafana.com/gpg.key | gpg --dearmor | tee /etc/apt/keyrings/grafana.gpg > /dev/null
   echo "deb [signed-by=/etc/apt/keyrings/grafana.gpg] https://apt.grafana.com stable main" | tee -a /etc/apt/sources.list.d/grafana.list

--- a/grafana/Dockerfile
+++ b/grafana/Dockerfile
@@ -1,0 +1,28 @@
+FROM ubuntu:24.04
+
+ENV GF_LOG_MODE=console
+ENV GF_PATHS_DATA=/var/lib/grafana
+ENV GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS=motherduck-duckdb-datasource
+ENV GF_HOMEPATH=/usr/share/grafana
+ENV GF_CONFIG=/etc/grafana/grafana.ini
+ENV GF_PATHS_PLUGINS=/var/lib/grafana/plugins
+ENV GF_PATHS_PROVISIONING=/etc/grafana/provisioning
+
+ENV GF_SECURITY_ADMIN_USER
+ENV GF_SECURITY_ADMIN_PASSWORD
+
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y apt-transport-https software-properties-common wget
+
+RUN mkdir -p /etc/apt/keyrings/
+
+RUN wget -q -O - https://apt.grafana.com/gpg.key | gpg --dearmor | tee /etc/apt/keyrings/grafana.gpg > /dev/null
+
+RUN echo "deb [signed-by=/etc/apt/keyrings/grafana.gpg] https://apt.grafana.com stable main" | tee -a /etc/apt/sources.list.d/grafana.list
+
+RUN apt-get update && apt-get -y install grafana
+
+USER grafana
+
+ENTRYPOINT ["grafana-server"]
+
+CMD ["--homepath=${GF_HOMEPATH}", "--config=${GF_CONFIG}", "cfg:default.log.mode=${GF_LOG_MODE}", "cfg:default.paths.data=${GF_PATHS_DATA}", "cfg:default.paths.plugins=${GF_PATHS_PLUGINS}", "cfg:default.paths.provisioning=${GF_PATHS_PROVISIONING}"]


### PR DESCRIPTION
This pull request updates the way the Grafana service is built and run in the development environment. The most significant change is that Grafana is now built from a custom Dockerfile instead of using the default image, allowing for more control over its configuration and plugins. Additionally, the Makefile and Docker Compose configuration have been adjusted to support these changes.

**Grafana service customization:**

* Added a new `grafana/Dockerfile` that builds Grafana from the official Ubuntu 24.04 base image, installs Grafana via the official repository, sets up environment variables, and configures plugin loading for `motherduck-duckdb-datasource`.
* Updated the `grafana` service in `compose.yml` to use the new custom build context and Dockerfile instead of the default Grafana image.

**Configuration and environment updates:**

* Moved the `GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS` environment variable from `compose.yml` into the Dockerfile, centralizing configuration. [[1]](diffhunk://#diff-3493e6b5ddf34891e572f911db893efd9e46af828e011ea778a7c1eb64763588L65) [[2]](diffhunk://#diff-49ffa7a5107cb654ad52a7c5a27086ece5f5c974d2c3417d9483b0addc821b7aR1-R25)

**Development workflow improvements:**

* Changed the `down` target in the `Makefile` to remove local Docker images when bringing down the stack, ensuring a clean rebuild for services like Grafana.


x86_64、arm64 のどちらのアーキテクチャの Ubuntu 24.04 コンテナ上でも、Grafana にプラグインをインストールして起動できるように、Ubuntu 24.04 ベースで Grafana をインストールする Dockerfile を追加して、docker compose up 時にイメージをビルドして使うように変更しています

