### PR TITLE
RTC Stats の session パネルの表示条件クエリから時間フィルタを削除する

### DIFF
--- a/grafana/dashboards/kohaku/rtc-stats.json
+++ b/grafana/dashboards/kohaku/rtc-stats.json
@@ -88,7 +88,7 @@
           "editorMode": "code",
           "format": 1,
           "rawQuery": true,
-          "rawSql": "SELECT\n    (req->>'$.timestamp') AS timestamp,\n    (req->>'$.max_connections') AS max_connections,\n    (req->>'$.total_connections') AS total_connections,\n    (req->>'$.version') AS version,\n    (req->>'$.node_name') AS node_name,\n    (req->>'$.group_id') AS group_id,\n    (req->>'$.spotlight') AS spotlight,\n    (req->>'$.connections') AS conenctions\nFROM session_webhook\nWHERE $__timeFilter(timestamp) AND (req->>'$.session_id') :: VARCHAR = $session_id\nORDER BY timestamp DESC\nLIMIT 1;",
+          "rawSql": "SELECT\n    (req->>'$.timestamp') AS timestamp,\n    (req->>'$.max_connections') AS max_connections,\n    (req->>'$.total_connections') AS total_connections,\n    (req->>'$.version') AS version,\n    (req->>'$.node_name') AS node_name,\n    (req->>'$.group_id') AS group_id,\n    (req->>'$.spotlight') AS spotlight,\n    (req->>'$.connections') AS conenctions\nFROM session_webhook\nWHERE (req->>'$.session_id') :: VARCHAR = $session_id\nORDER BY timestamp DESC\nLIMIT 1;",
           "refId": "A",
           "sql": {
             "columns": [
@@ -571,7 +571,7 @@
           "editorMode": "code",
           "format": 1,
           "rawQuery": true,
-          "rawSql": "WITH connections_list AS (\n  SELECT\n    (req->>'$.timestamp') AS timestamp,\n    (req->>'$.connections') AS connections\n  FROM session_webhook\n  WHERE $__timeFilter(timestamp) AND (req->>'$.session_id') :: VARCHAR = $session_id\nORDER BY timestamp DESC\nLIMIT 1\n)\nSELECT\n    value ->> 'connection_id' AS connection_id,\n    value ->> 'role' AS role,\n    value ->> 'client_id' AS client_id,\n    value ->> 'audio' AS audio,\n    value ->> 'video' AS video,\n    value ->> 'simulcast' AS simulcast,\n    value ->> 'connection_created_timestamp' AS connection_created_timestamp,\n    value ->> 'connection_destroyed_timestamp' AS connection_destroyed_timestamp,\nFROM connections_list,\n     json_each(connections_list.connections, '$');",
+          "rawSql": "WITH connections_list AS (\n  SELECT\n    (req->>'$.timestamp') AS timestamp,\n    (req->>'$.connections') AS connections\n  FROM session_webhook\n  WHERE (req->>'$.session_id') :: VARCHAR = $session_id\nORDER BY timestamp DESC\nLIMIT 1\n)\nSELECT\n    value ->> 'connection_id' AS connection_id,\n    value ->> 'role' AS role,\n    value ->> 'client_id' AS client_id,\n    value ->> 'audio' AS audio,\n    value ->> 'video' AS video,\n    value ->> 'simulcast' AS simulcast,\n    value ->> 'connection_created_timestamp' AS connection_created_timestamp,\n    value ->> 'connection_destroyed_timestamp' AS connection_destroyed_timestamp,\nFROM connections_list,\n     json_each(connections_list.connections, '$');",
           "refId": "A",
           "sql": {
             "columns": [


### PR DESCRIPTION
Grafana の RTC Stats の session パネルと Connections の session_webhook 条件から時間フィルタを除いています。

---
This pull request updates the SQL queries in the `grafana/dashboards/kohaku/rtc-stats.json` dashboard to remove the use of the Grafana time filter (`$__timeFilter`). Now, queries filter only by `session_id`. This change ensures that the queries always return the most recent data for a given session, regardless of the dashboard's time range selection.

**Dashboard query updates:**

* Removed the `$__timeFilter` condition from the main session stats query to always fetch the latest session data by `session_id`.
* Removed the `$__timeFilter` condition from the connections list query to ensure it retrieves the latest connections for the specified `session_id`.