### PR TITLE
unit ファイルを改善する

### DIFF
--- a/systemd/kohaku.service
+++ b/systemd/kohaku.service
@@ -11,6 +11,7 @@ Environment=UV_CACHE_DIR=/opt/kohaku/ingester/.cache
 Environment=HOME=/opt/kohaku
 WorkingDirectory=/opt/kohaku/ingester
 TimeoutStartSec=10min
+ExecCondition=/bin/test -f ${DUCKDB_DB_PATH}
 ExecStart=/opt/uv/bin/uv run python src/run.py \
 		--db ${DUCKDB_DB_PATH} \
 		--storage ${STORAGE} \

--- a/systemd/kohaku.service
+++ b/systemd/kohaku.service
@@ -26,5 +26,8 @@ ExecStartPost=/opt/uv/bin/uv run python src/run.py \
 		--retention_period ${RETENTION_PERIOD} \
 		delete
 
+Restart=on-failure
+RestartSec=5min
+
 [Install]
 WantedBy=multi-user.target

--- a/systemd/kohaku.service
+++ b/systemd/kohaku.service
@@ -1,14 +1,16 @@
 [Unit]
 Description=WebRTC Stats Analyzer Kohaku
-RefuseManualStop=true
+Wants=network-online.target
+After=network-online.target
 
 [Service]
 Type=oneshot
 User=kohaku
-EnvironmentFile=-/opt/kohaku/.env
+EnvironmentFile=/opt/kohaku/.env
 Environment=UV_CACHE_DIR=/opt/kohaku/ingester/.cache
 Environment=HOME=/opt/kohaku
 WorkingDirectory=/opt/kohaku/ingester
+TimeoutStartSec=10min
 ExecStart=/opt/uv/bin/uv run python src/run.py \
 		--db ${DUCKDB_DB_PATH} \
 		--storage ${STORAGE} \

--- a/systemd/kohaku.timer
+++ b/systemd/kohaku.timer
@@ -4,6 +4,7 @@ Description=Update DB
 [Timer]
 OnUnitInactiveSec=5min
 Persistent=true
+Unit=kohaku.service
 
 [Install]
 WantedBy=timers.target

--- a/systemd/kohaku.timer
+++ b/systemd/kohaku.timer
@@ -2,7 +2,7 @@
 Description=Update DB
 
 [Timer]
-OnCalendar=*-*-* *:00/5:00
+OnUnitInactiveSec=5min
 Persistent=true
 
 [Install]


### PR DESCRIPTION
This pull request updates the systemd configuration for the Kohaku WebRTC Stats Analyzer service and timer to improve reliability and ensure proper startup conditions. The main changes focus on making the service more robust, ensuring it only starts when the network is online and the database file exists, and adjusting the timer to trigger based on service inactivity rather than a fixed schedule.

Service reliability and startup conditions:

* Added `Wants=network-online.target` and `After=network-online.target` to ensure the service starts only after the network is online.
* Added `ExecCondition=/bin/test -f ${DUCKDB_DB_PATH}` to check that the database file exists before starting the service.
* Added `Restart=on-failure` and `RestartSec=5min` to automatically restart the service on failure with a 5-minute delay.
* Set `TimeoutStartSec=10min` to allow up to 10 minutes for the service to start.

Timer adjustments:

* Changed the timer to use `OnUnitInactiveSec=5min` instead of a fixed schedule, so it triggers 5 minutes after the service becomes inactive. Also explicitly set `Unit=kohaku.service` for clarity.