### PR TITLE
Kohaku が収集するログを明記する

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -22,18 +22,6 @@ Fluent Bit は Sora のログを読み込めるサーバ上に構築し、Kohaku
 
 RustFS または Amazon S3 は、構築した Fluent Bit、Kohaku からアクセスできるようにします
 
-## 収集対象のログ
-
-Kohaku では、Sora が出力するログのうち以下のログを Fluent Bit によって収集します。
-
-- `rtc_stats.jsonl`
-- `session_webhook.jsonl`
-
-収集対象のログの詳細は、以下の Fluent Bit の設定をご確認ください。
-
-- [fluent-bit.yml.rustfs](../fluent-bit/fluent-bit.yml.rustfs) : RustFS 用
-- [fluent-bit.yml.s3](../fluent-bit/fluent-bit.yml.s3) : S3 用
-
 ## Grafana の設定
 
 Grafana のインストール後にプラグインをインストールして使用する場合の設定手順です
@@ -124,6 +112,18 @@ make fluent-bit-yml
 ```bash
 make fluent-bit-yml-for-rustfs
 ```
+
+#### Fluent Bit による収集対象のログファイル
+
+Kohaku は、Fluent Bit を利用して、.env ファイルの SORA_LOG_PATH に指定したディレクトリ以下のログファイルを対象にログを収集します
+
+- rtc_stats.jsonl
+- session_webhook.jsonl
+
+ログ収集時の Fluent Bit の設定は、上記の make で生成された fluent-bit.yml でご確認ください
+
+また、既に Kohaku 以外の用途で Fluent Bit を使用している場合には、生成された fluent-bit.yml を参考にして、適宜、既存の Fluent Bit の設定に追加、または、変更して利用してください
+
 
 ### Kohaku ユーザの作成
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,9 +2,17 @@
 
 Ubuntu 24.04 上で動作を確認しています
 
-## 収集対象ログ
+## 収集対象のログ
 
-Kohaku では、Sora が出力するログのうち `rtc_stats.jsonl` と `session_webhook.jsonl` を収集対象とします。
+Kohaku では、Sora が出力するログのうち以下のログを収集対象とします。
+
+- `rtc_stats.jsonl`
+- `session_webhook.jsonl`
+
+収集対象のログの詳細は、以下の Fluent Bit の設定を参照してください。
+
+- [fluent-bit.yml.rustfs](../fluent-bit/fluent-bit.yml.rustfs) : RustFS 用
+- [fluent-bit.yml.s3](../fluent-bit/fluent-bit.yml.s3) : S3 用
 
 ## 環境
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -29,7 +29,7 @@ Kohaku では、Sora が出力するログのうち以下のログを Fluent Bit
 - `rtc_stats.jsonl`
 - `session_webhook.jsonl`
 
-収集対象のログの詳細は、以下の Fluent Bit の設定を参照してください。
+収集対象のログの詳細は、以下の Fluent Bit の設定をご確認ください。
 
 - [fluent-bit.yml.rustfs](../fluent-bit/fluent-bit.yml.rustfs) : RustFS 用
 - [fluent-bit.yml.s3](../fluent-bit/fluent-bit.yml.s3) : S3 用

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,6 +2,10 @@
 
 Ubuntu 24.04 上で動作を確認しています
 
+## 収集対象ログ
+
+Kohaku では、Sora が出力するログのうち `rtc_stats.jsonl` と `session_webhook.jsonl` を収集対象とします。
+
 ## 環境
 
 下記の 4 点で Kohaku 環境を構築します

--- a/docs/README.md
+++ b/docs/README.md
@@ -82,9 +82,13 @@ sudo make setup-grafana
 
 ### Fluent Bit の準備
 
+#### Fluent Bit のインストールから進める場合
+
 https://docs.fluentbit.io/manual/installation/getting-started-with-fluent-bit の手順で Fluent Bit をインストールします
 
 下記のいずれかのコマンドで Fluent Bit の設定をおこないます
+
+これらは、Kohaku 設定時の fluent-bit.yml の設定、および、systemd の設定を合わせておこないます
 
 - Amazon S3 の場合
 
@@ -98,8 +102,9 @@ sudo make setup-fluent-bit
 sudo make setup-fluent-bit-for-rustfs
 ```
 
-これらは、Kohaku 設定時の fluent-bit.yml の設定および、systemd の設定を合わせておこないますので、
-他の用途で Fluent Bit を使用する場合は、下記のコマンドで作成される fluent-bit.yml を参考にして組み込むようにしてください
+#### 既に Kohaku 以外の用途で Fluent Bit を利用している場合
+
+他の用途で Fluent Bit を利用している場合は、下記のコマンドで作成される fluent-bit.yml を参考にして、適宜、既存の Fluent Bit の設定に追加、または、変更して利用してください
 
 - Amazon S3 の場合
 
@@ -121,9 +126,6 @@ Kohaku は、Fluent Bit を利用して、.env ファイルの SORA_LOG_PATH に
 - session_webhook.jsonl
 
 ログ収集時の Fluent Bit の設定は、上記の make で生成された fluent-bit.yml でご確認ください
-
-また、既に Kohaku 以外の用途で Fluent Bit を使用している場合には、生成された fluent-bit.yml を参考にして、適宜、既存の Fluent Bit の設定に追加、または、変更して利用してください
-
 
 ### Kohaku ユーザの作成
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,18 +2,6 @@
 
 Ubuntu 24.04 上で動作を確認しています
 
-## 収集対象のログ
-
-Kohaku では、Sora が出力するログのうち以下のログを収集対象とします。
-
-- `rtc_stats.jsonl`
-- `session_webhook.jsonl`
-
-収集対象のログの詳細は、以下の Fluent Bit の設定を参照してください。
-
-- [fluent-bit.yml.rustfs](../fluent-bit/fluent-bit.yml.rustfs) : RustFS 用
-- [fluent-bit.yml.s3](../fluent-bit/fluent-bit.yml.s3) : S3 用
-
 ## 環境
 
 下記の 4 点で Kohaku 環境を構築します
@@ -33,6 +21,18 @@ Kohaku では、Sora が出力するログのうち以下のログを収集対�
 Fluent Bit は Sora のログを読み込めるサーバ上に構築し、Kohaku は Grafana は同一のサーバ上に構築します
 
 RustFS または Amazon S3 は、構築した Fluent Bit、Kohaku からアクセスできるようにします
+
+## 収集対象のログ
+
+Kohaku では、Sora が出力するログのうち以下のログを Fluent Bit によって収集します。
+
+- `rtc_stats.jsonl`
+- `session_webhook.jsonl`
+
+収集対象のログの詳細は、以下の Fluent Bit の設定を参照してください。
+
+- [fluent-bit.yml.rustfs](../fluent-bit/fluent-bit.yml.rustfs) : RustFS 用
+- [fluent-bit.yml.s3](../fluent-bit/fluent-bit.yml.s3) : S3 用
 
 ## Grafana の設定
 


### PR DESCRIPTION
docs/README.md に収集対象のログを明記するように修正しました。

## モチベーション

- docs/README.md から 「Sora のログ」としか記載がなく収集対象がわからない
- 収集対象を把握するには fluent-bit.yml を確認する必要があり不便