### PR TITLE
raise e の修正と ruff TRY201 有効化、.gitignore の整理

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,4 +20,12 @@ __pycache__
 *.pdb
 *.egg
 *.egg-info
+.mypy_cache
+.pytest_cache
+.ruff_cache
 .venv
+
+# agent
+.agents
+.claude
+.opencode

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ __pycache__
 *.pdb
 *.egg
 *.egg-info
+.venv

--- a/ingester/README.md
+++ b/ingester/README.md
@@ -1,6 +1,12 @@
 # ingester
 
+ingester は、S3 に保存されたログデータを DuckDB にインサートするためのツールです。S3 からデータを取得して、DuckDB に挿入することで、効率的なクエリ処理が可能になります。
+
+ingester は Systemd のサービスとして実行されることを想定しています。定期的に S3 からデータを取得して、DuckDB に挿入することで、 Grafana からのクエリに対して最新のデータを提供します。
+
 ## 実行環境の構築
+
+uv をインストールして、依存関係をインストールしてください。
 
 ```bash
 curl -LsSf https://astral.sh/uv/install.sh | sh

--- a/ingester/pyproject.toml
+++ b/ingester/pyproject.toml
@@ -24,6 +24,15 @@ test = [
   "testcontainers[minio]",
 ]
 
+[tool.ruff.lint]
+# ruff のデフォルトの lint ルール (E4/E7/E9, F) に加えて以下を有効化する
+# https://docs.astral.sh/ruff/rules/
+extend-select = [
+  # except 内の raise e を bare raise に置き換えるルール
+  # https://docs.astral.sh/ruff/rules/verbose-raise/
+  "TRY201",
+]
+
 [tool.pytest.ini_options]
 pythonpath = ["src"]
 testpaths = ["tests"]

--- a/ingester/src/run.py
+++ b/ingester/src/run.py
@@ -121,8 +121,6 @@ def sync_log_for_init(con, client, args, target):
     except duckdb.InvalidInputException as e:
         # まだディレクトリがないため、エラーを表示して次へ
         print(f"InvalidInputException ({target}): {e}")
-    except Exception as e:
-        raise e
 
 
 def sync_log_for_update(con, client, args, target):
@@ -230,7 +228,7 @@ def prepare_db_for_init(db_path):
             return
     except Exception as error:
         print(f"Unexpected error occurred while connecting to DB: {error}")
-        raise error
+        raise
 
 
 def is_initialized_db(db_path):
@@ -371,11 +369,11 @@ def delete(args):
             con.execute(f"ATTACH '{args.db}' AS db")
             con.execute(f"ATTACH '{copy_file}' AS copy")
             con.execute("COPY FROM DATABASE db TO copy")
-    except Exception as e:
+    except Exception:
         # 処理に失敗したときの残る可能性のあるファイルを削除する
         remove_delete_incompleted_copy_files(copy_file)
         # return code を 0 以外にするため例外を呼び出し元に投げる
-        raise e
+        raise
 
     try:
         # コピーしたファイルを、元の DB ファイルに上書きする
@@ -389,11 +387,11 @@ def delete(args):
             | stat.S_IWOTH,
         )
         shutil.move(copy_file, args.db)
-    except Exception as e:
+    except Exception:
         # 処理に失敗したときの残る可能性のあるファイルを削除する
         remove_delete_incompleted_copy_files(copy_file)
         # return code を 0 以外にするため例外を呼び出し元に投げる
-        raise e
+        raise
 
 
 def insert_log_from_s3(con, client, table_name, bucket, prefix):
@@ -415,9 +413,9 @@ def insert_log_from_s3(con, client, table_name, bucket, prefix):
             insert_log(con, table_name, target_urls)
             update_s3_object_table(con, table_name, latest_object(target_log_objects))
             con.commit()
-        except Exception as e:
+        except Exception:
             con.rollback()
-            raise e
+            raise
 
 
 def insert_log(con, table_name, target_urls):


### PR DESCRIPTION
## Summary

- `ingester/src/run.py` の `raise e` / `raise error` を bare `raise` に置き換え（4 箇所）。`sync_log_for_init` の `except Exception: raise e` ブロックは無意味なため削除
- `ingester/pyproject.toml` に `[tool.ruff.lint]` を追加し、`extend-select = ["TRY201"]` で再発防止
- `.gitignore` に `.venv` / `.mypy_cache` / `.pytest_cache` / `.ruff_cache` / `.agents` / `.claude` / `.opencode` を追加
- `ingester/README.md` に説明を追加

## Test plan

- [x] `uv run ruff check` が pass
- [x] `uv run pytest` が pass (19 件)
- [x] レビュアー: 例外伝播の挙動が変わっていないこと（トレースバックが保持されていること）の確認