### PR TITLE
0001-0002 カーソル脱落と重複データを修正する

### DIFF
--- a/ingester/DUCKDB_COLUMNS/connection.yml
+++ b/ingester/DUCKDB_COLUMNS/connection.yml
@@ -1,28 +1,29 @@
----
-connection_id: VARCHAR
-timestamp: TIMESTAMPTZ
-sora_client: VARCHAR
-session_id: VARCHAR
-role: VARCHAR
-channel_id: VARCHAR
-rtc_stats: JSON
-spotlight: BOOLEAN
-bundle_id: VARCHAR
-client_id: VARCHAR
-audio: JSON
-video: JSON
-simulcast: BOOLEAN
-recording_block: BOOLEAN
-data_channel_signaling: JSON
-ignore_disconnect_websocket: BOOLEAN
-turn_transport_type: VARCHAR
-created_timestamp: TIMESTAMPTZ
-destroyed_timestamp: TIMESTAMPTZ
-destroyed_reason: VARCHAR
-e2ee: BOOLEAN
-local_stats: JSON
-signaling_terminate_reason: VARCHAR
-websocket_terminated_reason: VARCHAR
-type_disconnect_reason: VARCHAR
-data_channel_exit_reason: VARCHAR
-simulcast_encodings: JSON
+columns:
+  connection_id: VARCHAR
+  timestamp: TIMESTAMPTZ
+  sora_client: VARCHAR
+  session_id: VARCHAR
+  role: VARCHAR
+  channel_id: VARCHAR
+  rtc_stats: JSON
+  spotlight: BOOLEAN
+  bundle_id: VARCHAR
+  client_id: VARCHAR
+  audio: JSON
+  video: JSON
+  simulcast: BOOLEAN
+  recording_block: BOOLEAN
+  data_channel_signaling: JSON
+  ignore_disconnect_websocket: BOOLEAN
+  turn_transport_type: VARCHAR
+  created_timestamp: TIMESTAMPTZ
+  destroyed_timestamp: TIMESTAMPTZ
+  destroyed_reason: VARCHAR
+  e2ee: BOOLEAN
+  local_stats: JSON
+  signaling_terminate_reason: VARCHAR
+  websocket_terminated_reason: VARCHAR
+  type_disconnect_reason: VARCHAR
+  data_channel_exit_reason: VARCHAR
+  simulcast_encodings: JSON
+primary_key: []

--- a/ingester/DUCKDB_COLUMNS/rtc_stats.yml
+++ b/ingester/DUCKDB_COLUMNS/rtc_stats.yml
@@ -1,20 +1,24 @@
----
-connection_id: VARCHAR
-id: VARCHAR
-label: VARCHAR
-timestamp: TIMESTAMPTZ
-type: VARCHAR
-version: VARCHAR
-node_name: VARCHAR
-session_id: VARCHAR
-role: VARCHAR
-channel_id: VARCHAR
-spotlight: BOOLEAN
-bundle_id: VARCHAR
-client_id: VARCHAR
-simulcast: BOOLEAN
-log_written: BOOLEAN
-rtc_data: JSON
-rtc_id: VARCHAR
-rtc_timestamp: DOUBLE
-rtc_type: VARCHAR
+columns:
+  connection_id: VARCHAR
+  id: VARCHAR
+  label: VARCHAR
+  timestamp: TIMESTAMPTZ
+  type: VARCHAR
+  version: VARCHAR
+  node_name: VARCHAR
+  session_id: VARCHAR
+  role: VARCHAR
+  channel_id: VARCHAR
+  spotlight: BOOLEAN
+  bundle_id: VARCHAR
+  client_id: VARCHAR
+  simulcast: BOOLEAN
+  log_written: BOOLEAN
+  rtc_data: JSON
+  rtc_id: VARCHAR
+  rtc_timestamp: DOUBLE
+  rtc_type: VARCHAR
+primary_key:
+  - connection_id
+  - rtc_id
+  - rtc_timestamp

--- a/ingester/DUCKDB_COLUMNS/session_webhook.yml
+++ b/ingester/DUCKDB_COLUMNS/session_webhook.yml
@@ -1,4 +1,6 @@
----
-id: VARCHAR
-timestamp: TIMESTAMPTZ
-req: JSON
+columns:
+  id: VARCHAR
+  timestamp: TIMESTAMPTZ
+  req: JSON
+primary_key:
+  - id

--- a/ingester/src/run.py
+++ b/ingester/src/run.py
@@ -76,6 +76,9 @@ def positive_int(value):
 def load_columns(targets=LOG_TARGETS, columns_dir=COLUMNS_DIR):
     """targets 各テーブルのカラム定義 YAML を columns_dir から読み込んで辞書として返す。
 
+    戻り値は `{target: {"columns": {カラム名: 型}, "primary_key": [PK カラム名...]}}` の形式。
+    primary_key が定義されていないテーブルは空リストになる。
+
     YAML 欠損はデプロイ / イメージビルド側の不備なので RuntimeError で送出し、
     handle_cli_error では拾わずトレースバック付きで上位に伝播させる (「Run 'init'」
     のようなユーザー向け 1 行メッセージにはしない)。
@@ -89,12 +92,25 @@ def load_columns(targets=LOG_TARGETS, columns_dir=COLUMNS_DIR):
             raise RuntimeError(f"Column definition file not found: {file_path}")
 
         with open(file_path) as f:
-            columns = yaml.safe_load(f)
+            data = yaml.safe_load(f)
+            if not isinstance(data, dict) or "columns" not in data:
+                raise ValueError(
+                    f"Invalid format in {file_path}, expected a dictionary with 'columns'."
+                )
+            columns = data["columns"]
             if not isinstance(columns, dict):
                 raise ValueError(
-                    f"Invalid format in {file_path}, expected a dictionary."
+                    f"Invalid format in {file_path}, 'columns' must be a dictionary."
                 )
-            duckdb_columns[target] = columns
+            primary_key = data.get("primary_key", [])
+            if not isinstance(primary_key, list):
+                raise ValueError(
+                    f"Invalid format in {file_path}, 'primary_key' must be a list."
+                )
+            duckdb_columns[target] = {
+                "columns": columns,
+                "primary_key": primary_key,
+            }
 
     return duckdb_columns
 
@@ -488,7 +504,10 @@ def create_log_table(con, table_name, target_urls):
     """指定された S3 オブジェクト URL から DuckDB テーブルを新規作成する。
 
     target_urls の JSON 内容を読み込み、DUCKDB_COLUMNS で定義したスキーマでテーブル化する。
-    既にテーブルが存在する場合は何もしない。LOG_TARGETS 外のテーブル名は ValueError で弾く。
+    primary_key が定義されているテーブルは PK 付きで作成し、 insert は ON CONFLICT DO NOTHING
+    で重複行を吸収する (rel.create / rel.insert_into は PK と ON CONFLICT を扱えないため、
+    生 SQL で組み立てる)。 既にテーブルが存在する場合は何もしない。 LOG_TARGETS 外の
+    テーブル名は ValueError で弾く。
     """
     duckdb_columns = load_columns()
     require_known_table(table_name, duckdb_columns)
@@ -498,9 +517,13 @@ def create_log_table(con, table_name, target_urls):
         return
 
     # テーブルを作成する
-    columns = duckdb_columns[table_name]
-    rel = con.read_json(target_urls, union_by_name=True, columns=columns)
-    rel.create(table_name)
+    columns = duckdb_columns[table_name]["columns"]
+    primary_key = duckdb_columns[table_name]["primary_key"]
+    column_defs = ", ".join(f"{name} {col_type}" for name, col_type in columns.items())
+    if primary_key:
+        column_defs += f", PRIMARY KEY ({', '.join(primary_key)})"
+    con.execute(f"CREATE TABLE {table_name} ({column_defs})")
+    insert_log(con, table_name, target_urls)
     print(
         f"Created table {table_name} from {len(target_urls)} object(s).",
         file=sys.stderr,
@@ -650,32 +673,51 @@ def insert_log_from_s3(
     までしか進めないため、 update_maximum_load を超えた新しい側は次回以降の update で
     is_after_s3_cursor が True 判定して順次取得する。
 
+    カーソルと同値の last_modified を持つオブジェクト (カーソル行自身を除く) は、
+    バッチ分割の対象外として毎回の update で全件取り込む (カーソル通過後に同値の
+    last_modified で現れたオブジェクトを拾うため。 重複行は PK 制約 + ON CONFLICT
+    DO NOTHING で吸収する)。
+
     insert_log とカーソル更新は con.begin() / con.commit() で囲み、 途中失敗時は
     con.rollback() で「行 insert とカーソル更新」 を atomic に保つ (中途半端な状態で
     残さない)。
     """
     log_objects = list_objects(client, bucket, f"{prefix}/{table_name}/")
 
+    cursor_last_modified, cursor_object_name = cursor_key
     target_log_objects = [
         obj
         for obj in log_objects
         if is_after_s3_cursor((obj.last_modified, obj.object_name), cursor_key)
     ]
+    same_last_modified_objects = [
+        obj
+        for obj in log_objects
+        if obj.last_modified == cursor_last_modified
+        and obj.object_name != cursor_object_name
+    ]
 
     # 長時間停止後に大量ファイルが蓄積したケースに備え、古い方からバッチで取り込む。
     # 降順ソートされているため、末尾側 update_maximum_load 件が古い順のバッチになる。
+    # 同値グループはバッチ分割の対象外とする (カーソルと同値のオブジェクトは毎回全件
+    # 取り込み、 重複は PK で吸収する)。
     if len(target_log_objects) > update_maximum_load:
         target_log_objects = target_log_objects[-update_maximum_load:]
 
-    if len(target_log_objects) == 0:
+    if len(target_log_objects) == 0 and len(same_last_modified_objects) == 0:
         return
 
     target_urls = get_target_urls(bucket, target_log_objects)
+    same_urls = get_target_urls(bucket, same_last_modified_objects)
     con.begin()
     try:
-        insert_log(con, table_name, target_urls)
-        # 先頭がこのバッチの最新
-        update_s3_objects_table(con, table_name, target_log_objects[0])
+        if target_urls:
+            insert_log(con, table_name, target_urls)
+        if same_urls:
+            insert_log(con, table_name, same_urls)
+        if target_log_objects:
+            # 先頭がこのバッチの最新
+            update_s3_objects_table(con, table_name, target_log_objects[0])
         con.commit()
     except Exception:
         # rollback が disk full 等で失敗すると元例外が __context__ に沈み、stderr には
@@ -693,13 +735,24 @@ def insert_log(con, table_name, target_urls):
 
     create_log_table と同じ許可リスト検査 (require_known_table) を経由して、
     SQL への直接埋め込みを行わない経路でも防御チェックを共有する。
+    PK を持つテーブルでは ON CONFLICT DO NOTHING で重複行を吸収する
+    (rel.insert_into は ON CONFLICT を扱えないため、 生 SQL で組み立てる)。
     """
     duckdb_columns = load_columns()
     require_known_table(table_name, duckdb_columns)
 
-    columns = duckdb_columns[table_name]
-    rel = con.read_json(target_urls, union_by_name=True, columns=columns)
-    rel.insert_into(table_name)
+    columns = duckdb_columns[table_name]["columns"]
+    column_names = ", ".join(columns.keys())
+    if duckdb_columns[table_name]["primary_key"]:
+        conflict_clause = " ON CONFLICT DO NOTHING"
+    else:
+        conflict_clause = ""
+    con.execute(
+        f"INSERT INTO {table_name} ({column_names}) "
+        f"SELECT {column_names} FROM read_json(?, union_by_name=true, columns=?)"
+        f"{conflict_clause}",
+        [target_urls, columns],
+    )
 
 
 def get_s3_objects_cursor(con, log_type):

--- a/ingester/tests/test_ingester.py
+++ b/ingester/tests/test_ingester.py
@@ -400,10 +400,13 @@ def test_update(s3_client, rustfs_endpoint, tmp_path):
         assert result[0] == len(objects)
 
     # 新規の log データを RustFS に追加した後に update を呼び出して、データ数が増えることを確認する
+    # (既存行をそのまま再 put すると natural key の PK で重複吸収されるため、 connection_id を
+    # 変更して一意な行として put する)
     new_log_file = os.path.join(LOG_DIR, "rtc_stats.jsonl")
     with open(new_log_file, "rb") as data:
         for line in data:
             parsed_log = json.loads(line)
+            parsed_log["connection_id"] = f"{parsed_log['connection_id']}-update"
             now = datetime.datetime.now(datetime.UTC)
             log_data = json.dumps(parsed_log).encode("utf-8")
             compressed_log_data = gzip.compress(log_data)
@@ -504,10 +507,14 @@ def test_update_skips_broken_object_and_continues_other_targets(
     )
 
     # 正常な rtc_stats オブジェクトも同時に配置する。
+    # (既存行をそのまま再 put すると natural key の PK で重複吸収されるため、 connection_id を
+    # 変更して一意な行として put する)
     new_log_file = os.path.join(LOG_DIR, "rtc_stats.jsonl")
     with open(new_log_file, "rb") as data:
         first_line = data.readline()
-    compressed = gzip.compress(first_line)
+    parsed_log = json.loads(first_line)
+    parsed_log["connection_id"] = f"{parsed_log['connection_id']}-broken-test"
+    compressed = gzip.compress(json.dumps(parsed_log).encode("utf-8"))
     s3_client.put_object(
         BUCKET,
         data_path(PREFIX, "rtc_stats", directory),
@@ -893,10 +900,14 @@ def test_update_maximum_load_splits_batches(s3_client, rustfs_endpoint, tmp_path
     assert len(new_lines) == 5
 
     for line in new_lines:
+        # 既存行をそのまま再 put すると natural key の PK で重複吸収されるため、
+        # connection_id を変更して一意な行として put する
+        parsed_log = json.loads(line)
+        parsed_log["connection_id"] = f"{parsed_log['connection_id']}-batch"
         now = datetime.datetime.now(datetime.UTC)
         directory = now.strftime("%Y/%m/%d")
         s3_path = data_path(PREFIX, "rtc_stats", directory)
-        compressed_log_data = gzip.compress(line)
+        compressed_log_data = gzip.compress(json.dumps(parsed_log).encode("utf-8"))
         s3_client.put_object(
             BUCKET,
             s3_path,
@@ -961,10 +972,14 @@ def test_update_maximum_load_one_takes_single_object_per_call(
     assert len(new_lines) == 3
 
     for line in new_lines:
+        # 既存行をそのまま再 put すると natural key の PK で重複吸収されるため、
+        # connection_id を変更して一意な行として put する
+        parsed_log = json.loads(line)
+        parsed_log["connection_id"] = f"{parsed_log['connection_id']}-batch"
         now = datetime.datetime.now(datetime.UTC)
         directory = now.strftime("%Y/%m/%d")
         s3_path = data_path(PREFIX, "rtc_stats", directory)
-        compressed_log_data = gzip.compress(line)
+        compressed_log_data = gzip.compress(json.dumps(parsed_log).encode("utf-8"))
         s3_client.put_object(
             BUCKET,
             s3_path,
@@ -992,3 +1007,123 @@ def test_update_maximum_load_one_takes_single_object_per_call(
     # 4 回目: 取り込むものが無いため件数が変わらない
     update(batch_args)
     assert fetch_rtc_stats_count() == initial_count + 3
+
+
+def test_update_ingests_same_last_modified_object(s3_client, rustfs_endpoint, tmp_path):
+    """カーソルと同値の last_modified を持つオブジェクトが、カーソルより辞書順が小さくても取り込まれることを確認する。
+
+    カーソル通過後に同値の last_modified で現れたオブジェクトは、 旧実装では is_after_s3_cursor
+    (タプル辞書順比較) で False になり永久脱落する。 本テストは s3_objects のカーソル行の書き換えで
+    「カーソルが同値グループの辞書順最大に進んだ状態」をタイミングの偶然に依存せずに再現し、
+    同値グループの再走査でオブジェクトが取り込まれることを検証する。
+    """
+    duckdb_filepath = str(tmp_path / "duck.db")
+    args = make_args_for_s3(duckdb_filepath, rustfs_endpoint)
+
+    # init で fixture の全行を取り込む
+    init(args)
+
+    with duckdb.connect(duckdb_filepath) as con:
+        con.execute("SELECT COUNT(*) FROM rtc_stats")
+        result = con.fetchone()
+        assert result is not None
+        initial_count = result[0]
+    assert initial_count > 0
+
+    # カーソルと同値の last_modified になる新規オブジェクトを put する
+    # (既存行と重複しないよう connection_id を変更する)
+    new_log_file = os.path.join(LOG_DIR, "rtc_stats.jsonl")
+    with open(new_log_file, "rb") as data:
+        line = data.readline()
+    parsed_log = json.loads(line)
+    parsed_log["connection_id"] = f"{parsed_log['connection_id']}-same-lm"
+    compressed = gzip.compress(json.dumps(parsed_log).encode("utf-8"))
+    now = datetime.datetime.now(datetime.UTC)
+    directory = now.strftime("%Y/%m/%d")
+    s3_client.put_object(
+        BUCKET,
+        data_path(PREFIX, "rtc_stats", directory),
+        io.BytesIO(compressed),
+        length=len(compressed),
+    )
+
+    # put したオブジェクトの last_modified を取得する (S3 上の最新オブジェクト)
+    objects = list(
+        s3_client.list_objects(BUCKET, prefix=f"{PREFIX}/rtc_stats/", recursive=True)
+    )
+    new_obj = max(objects, key=lambda obj: (obj.last_modified, obj.object_name))
+
+    # カーソルを「新規オブジェクトと同値の last_modified の辞書順最大」に書き換える
+    with duckdb.connect(duckdb_filepath) as con:
+        con.execute(
+            "UPDATE s3_objects SET last_modified=?, object_name=? WHERE type=?",
+            (new_obj.last_modified, "zzzzzzzzzzzzzzzzzzzz.gz", "rtc_stats"),
+        )
+
+    # update で同値グループの再走査により新規オブジェクトが取り込まれる
+    update(args)
+
+    with duckdb.connect(duckdb_filepath) as con:
+        con.execute("SELECT COUNT(*) FROM rtc_stats")
+        result = con.fetchone()
+        assert result is not None
+        result = result[0]
+    assert result == initial_count + 1
+
+
+def test_update_deduplicates_retransmitted_object(
+    s3_client_empty, rustfs_endpoint, tmp_path
+):
+    """fluent-bit の再送 (同一 event の別 UUID put) で重複行が 1 行のみになることを確認する。
+
+    PK 制約 + INSERT ... ON CONFLICT DO NOTHING により、 再送された同一 natural key の行が
+    吸収されることを、 クロスバッチ手順 (U1 取り込み → U2 put → update) で検証する。
+    """
+    duckdb_filepath = str(tmp_path / "duck.db")
+    args = make_args_for_s3(duckdb_filepath, rustfs_endpoint)
+
+    # 空バケットで init する (オブジェクトが無いため LOG_TARGETS テーブルは作られない)
+    init(args)
+
+    # 同一 event を 2 つの UUID で put する (同一 last_modified になった場合のカーソル比較に
+    # 備えて辞書順 U1 < U2 を固定する)
+    new_log_file = os.path.join(LOG_DIR, "rtc_stats.jsonl")
+    with open(new_log_file, "rb") as data:
+        line = data.readline()
+    compressed = gzip.compress(line)
+    now = datetime.datetime.now(datetime.UTC)
+    directory = now.strftime("%Y/%m/%d")
+    s3_path_u1 = f"{PREFIX}/rtc_stats/{directory}/a.gz"
+    s3_path_u2 = f"{PREFIX}/rtc_stats/{directory}/b.gz"
+    s3_client_empty.put_object(
+        BUCKET,
+        s3_path_u1,
+        io.BytesIO(compressed),
+        length=len(compressed),
+    )
+
+    # U1 を取り込む (初登場 target のため initialize_log_table が走る)
+    update(args)
+    with duckdb.connect(duckdb_filepath) as con:
+        con.execute("SELECT COUNT(*) FROM rtc_stats")
+        result = con.fetchone()
+        assert result is not None
+        count_after_u1 = result[0]
+    assert count_after_u1 == 1
+
+    # U2 (同一 event の別 UUID) を put して update する
+    s3_client_empty.put_object(
+        BUCKET,
+        s3_path_u2,
+        io.BytesIO(compressed),
+        length=len(compressed),
+    )
+    update(args)
+
+    with duckdb.connect(duckdb_filepath) as con:
+        con.execute("SELECT COUNT(*) FROM rtc_stats")
+        result = con.fetchone()
+        assert result is not None
+        result = result[0]
+    # 重複行は PK 制約で吸収され 1 行のみ
+    assert result == 1

--- a/ingester/tests/test_run_unit.py
+++ b/ingester/tests/test_run_unit.py
@@ -358,10 +358,29 @@ def test_ensure_safe_sql_string_literal_error_message_shows_codepoint_and_index(
 
 
 def test_load_columns_returns_dict_for_valid_yaml(tmp_path):
-    """columns_dir に正常な dict 形式の YAML があるとき、 target をキーに columns 辞書を返すことを確認する。"""
-    (tmp_path / "rtc_stats.yml").write_text("timestamp: TIMESTAMPTZ\nid: VARCHAR\n")
+    """columns_dir に正常な dict 形式の YAML があるとき、 target をキーに columns と primary_key を返すことを確認する。"""
+    (tmp_path / "rtc_stats.yml").write_text(
+        "columns:\n  timestamp: TIMESTAMPTZ\n  id: VARCHAR\nprimary_key:\n  - id\n"
+    )
     result = run.load_columns(targets=("rtc_stats",), columns_dir=str(tmp_path))
-    assert result == {"rtc_stats": {"timestamp": "TIMESTAMPTZ", "id": "VARCHAR"}}
+    assert result == {
+        "rtc_stats": {
+            "columns": {"timestamp": "TIMESTAMPTZ", "id": "VARCHAR"},
+            "primary_key": ["id"],
+        }
+    }
+
+
+def test_load_columns_returns_empty_primary_key_when_omitted(tmp_path):
+    """primary_key が定義されていない YAML では空リストを返すことを確認する。"""
+    (tmp_path / "rtc_stats.yml").write_text("columns:\n  timestamp: TIMESTAMPTZ\n")
+    result = run.load_columns(targets=("rtc_stats",), columns_dir=str(tmp_path))
+    assert result == {
+        "rtc_stats": {
+            "columns": {"timestamp": "TIMESTAMPTZ"},
+            "primary_key": [],
+        }
+    }
 
 
 def test_load_columns_raises_runtime_error_when_file_missing(tmp_path):


### PR DESCRIPTION
## 変更内容

- [0001] カーソルと同値の last_modified を持つオブジェクトを毎回の update で再走査して取り込む（辞書順で永久脱落する問題の修正）
- [0002] rtc_stats / session_webhook テーブルに natural key の PK 制約を追加し、 重複行を INSERT ... ON CONFLICT DO NOTHING で吸収する

## 注意点

- 既存 DB は再 init が必要（PK なしテーブルへの ON CONFLICT は失敗するため）