### PR TITLE
fluent-bit 識別子を S3 オブジェクトキーに含める

### DIFF
--- a/fluent-bit/fluent-bit.yml.rustfs
+++ b/fluent-bit/fluent-bit.yml.rustfs
@@ -24,7 +24,7 @@ pipeline:
       bucket: ${S3_BUCKET}
       endpoint: ${S3_ENDPOINT}
       compression: gzip
-      s3_key_format: /${S3_PREFIX}/$TAG/%Y/%m/%d/$UUID.gz
+      s3_key_format: /${S3_PREFIX}/$TAG/%Y/%m/%d/${HOSTNAME}-$UUID.gz
       upload_timeout: 5m
       json_date_key: off
     - name: s3
@@ -32,7 +32,7 @@ pipeline:
       bucket: ${S3_BUCKET}
       endpoint: ${S3_ENDPOINT}
       compression: gzip
-      s3_key_format: /${S3_PREFIX}/$TAG/%Y/%m/%d/$UUID.gz
+      s3_key_format: /${S3_PREFIX}/$TAG/%Y/%m/%d/${HOSTNAME}-$UUID.gz
       upload_timeout: 5m
       json_date_key: off
 

--- a/fluent-bit/fluent-bit.yml.s3
+++ b/fluent-bit/fluent-bit.yml.s3
@@ -24,7 +24,7 @@ pipeline:
       bucket: ${S3_BUCKET}
       region: ${S3_REGION}
       compression: gzip
-      s3_key_format: /${S3_PREFIX}/$TAG/%Y/%m/%d/$UUID.gz
+      s3_key_format: /${S3_PREFIX}/$TAG/%Y/%m/%d/${HOSTNAME}-$UUID.gz
       upload_timeout: 5m
       json_date_key: off
     - name: s3
@@ -32,7 +32,7 @@ pipeline:
       bucket: ${S3_BUCKET}
       region: ${S3_REGION}
       compression: gzip
-      s3_key_format: /${S3_PREFIX}/$TAG/%Y/%m/%d/$UUID.gz
+      s3_key_format: /${S3_PREFIX}/$TAG/%Y/%m/%d/${HOSTNAME}-$UUID.gz
       upload_timeout: 5m
       json_date_key: off
 

--- a/ingester/tests/fixtures/fluent-bit/default-fluent-bit.yml.j2
+++ b/ingester/tests/fixtures/fluent-bit/default-fluent-bit.yml.j2
@@ -3,6 +3,7 @@ env:
   S3_BUCKET: {{ s3_bucket }}
   S3_PREFIX: {{ s3_prefix }}
   SORA_LOG_PATH: {{ sora_log_path }}
+  HOSTNAME: {{ hostname }}
 
 service:
   flush:        1
@@ -30,7 +31,7 @@ pipeline:
       bucket: ${S3_BUCKET}
       endpoint: ${S3_ENDPOINT}
       compression: gzip
-      s3_key_format: /${S3_PREFIX}/$TAG/%Y/%m/%d/$UUID.gz
+      s3_key_format: /${S3_PREFIX}/$TAG/%Y/%m/%d/${HOSTNAME}-$UUID.gz
       upload_timeout: 10s
       json_date_key: off
     - name: s3
@@ -38,7 +39,7 @@ pipeline:
       bucket: ${S3_BUCKET}
       endpoint: ${S3_ENDPOINT}
       compression: gzip
-      s3_key_format: /${S3_PREFIX}/$TAG/%Y/%m/%d/$UUID.gz
+      s3_key_format: /${S3_PREFIX}/$TAG/%Y/%m/%d/${HOSTNAME}-$UUID.gz
       upload_timeout: 10s
       json_date_key: off
 

--- a/ingester/tests/fluent_bit_helper.py
+++ b/ingester/tests/fluent_bit_helper.py
@@ -22,6 +22,7 @@ def create_fluent_bit_config(
     s3_bucket: str = "kohaku",
     s3_prefix: str = "log",
     sora_log_path: str = FLUENT_BIT_SORA_LOG_PATH,
+    hostname: str = "fluent-bit-test",
 ) -> None:
     """fluent-bit 設定テンプレートを描画して設定ファイルを書き出す。"""
     template_text = Path(template_path).read_text(encoding="utf-8")
@@ -30,6 +31,7 @@ def create_fluent_bit_config(
         s3_bucket=s3_bucket,
         s3_prefix=s3_prefix,
         sora_log_path=sora_log_path,
+        hostname=hostname,
     )
     config_path.write_text(
         config_text,

--- a/ingester/tests/test_fluent_bit_rustfs_integration.py
+++ b/ingester/tests/test_fluent_bit_rustfs_integration.py
@@ -394,3 +394,45 @@ def test_runpy_init_fails_when_bucket_not_found(tmp_path, rustfs_network_stack):
     assert f"S3 bucket not found: {BUCKET}" in run.stderr, (
         f"stderr に 'S3 bucket not found: {BUCKET}' が含まれていません: {run.stderr}"
     )
+
+
+def test_fluent_bit_puts_object_key_with_hostname(tmp_path, rustfs_network_ready):
+    """fluent-bit が put したオブジェクトキーに HOSTNAME が含まれることを確認する。
+
+    複数 fluent-bit 環境でオブジェクトがどのノード由来か判別できるようにするため、
+    s3_key_format に ${HOSTNAME} が含まれる。本テストは fixture の env に HOSTNAME を
+    明示し、 put されたオブジェクトのキーにその値が含まれることを検証する。
+    """
+    network, endpoint, client = rustfs_network_ready
+    repo_root = Path(__file__).resolve().parents[2]
+    ingester_dir = repo_root / "ingester"
+    source_log_dir = ingester_dir / "tests" / "log"
+    log_dir = create_test_log_dir(tmp_path, source_log_dir)
+
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    config_path = tmp_path / "fluent-bit.yml"
+    # HOSTNAME を明示して fluent-bit 設定を生成する
+    hostname = "fluent-bit-test-node"
+    create_fluent_bit_config(config_path, s3_bucket=BUCKET, hostname=hostname)
+
+    run_fluent_bit_and_wait(
+        network,
+        log_dir,
+        config_path,
+        state_dir,
+        client,
+        {
+            f"{PREFIX}/rtc_stats/": 1,
+        },
+    )
+
+    # put されたオブジェクトのキーにホスト名が含まれることを確認する
+    objects = list(
+        client.list_objects(BUCKET, prefix=f"{PREFIX}/rtc_stats/", recursive=True)
+    )
+    assert len(objects) > 0
+    for obj in objects:
+        assert hostname in obj.object_name, (
+            f"オブジェクトキーにホスト名 ({hostname}) が含まれていません: {obj.object_name}"
+        )


### PR DESCRIPTION
## 概要

複数 fluent-bit 環境で、 S3 に put されたオブジェクトがどの fluent-bit ノード由来か判別できるように、 `s3_key_format` にホスト名を含める。

## 変更内容

- `fluent-bit/fluent-bit.yml.rustfs`・`fluent-bit/fluent-bit.yml.s3`: `s3_key_format` を `/${S3_PREFIX}/$TAG/%Y/%m/%d/${HOSTNAME}-$UUID.gz` に変更
- `ingester/tests/fixtures/fluent-bit/default-fluent-bit.yml.j2`: env に `HOSTNAME` を追加 + `s3_key_format` 変更
- `ingester/tests/fluent_bit_helper.py`: `create_fluent_bit_config` に `hostname` パラメータを追加
- `ingester/tests/test_fluent_bit_rustfs_integration.py`: put されたオブジェクトキーにホスト名が含まれることを検証する統合テストを追加

## 完了条件

- [x] 3 ファイルの `s3_key_format` に `${HOSTNAME}` が含まれる
- [x] 統合テストが追加され、通過する
- [x] 既存の統合テストが引き続き通過する