### PR TITLE
initial_maximum_load のデフォルト値を 1000 に変更する

### DIFF
--- a/.env.common.template
+++ b/.env.common.template
@@ -26,7 +26,7 @@
 # ingester の実行間隔（秒）（Docker 使用時のみ、Docker を使用しない場合は systemd/kohaku.timer で設定します）
 # UPDATE_INTERVAL=300
 # init 時、および update 時にテーブル未作成だった場合の、初回テーブル作成における読み込み件数の上限
-# INITIAL_MAXIMUM_LOAD=100
+# INITIAL_MAXIMUM_LOAD=1000
 # update 時の 1 バッチで取り込むログ件数の上限。長時間停止後の復帰時に大量蓄積したログをバッチ分割するために使う
 # UPDATE_MAXIMUM_LOAD=100
 # ingester が DuckDB 上で保持するログの期間（日数）

--- a/ingester/README.md
+++ b/ingester/README.md
@@ -25,7 +25,7 @@ uv run python src/run.py --db ./duck.db \
                       --s3_secret_access_key "$AWS_SECRET_ACCESS_KEY" \
                       --s3_bucket kohaku \
                       --s3_prefix log  \
-                      --initial_maximum_load 100 \
+                      --initial_maximum_load 1000 \
                       init
 ```
 

--- a/ingester/src/run.py
+++ b/ingester/src/run.py
@@ -36,7 +36,11 @@ DEFAULT_S3_REGION = "ap-northeast-1"
 DEFAULT_RETENTION_PERIOD = 7
 # init 時に読み込むファイル数の上限。古すぎるデータを取り込まないために
 # ユーザーが指定する上限であり、超過した古い側オブジェクトは意図的に取り込まれない。
-DEFAULT_INITIAL_MAXIMUM_LOAD = 100
+# デフォルト値 1000 は複数 fluent-bit (10 台) 構成で単一運用と同等の約 8 時間
+# (500 分) のカバーを実現する値 (カバーしたい分数 500 ÷ upload_timeout 5 分 ×
+# 10 台)。20 台構成では約 4 時間。単一運用では初回取り込み量が 10 倍になるが、
+# 対象オブジェクトは gzip 圧縮済みの小さな JSON オブジェクトで実害は限定的。
+DEFAULT_INITIAL_MAXIMUM_LOAD = 1000
 # update 時に 1 回で取り込むファイル数の上限。停止後の復帰時に大量蓄積したログを
 # バッチ分割するために用いる。
 DEFAULT_UPDATE_MAXIMUM_LOAD = 100

--- a/ingester/tests/test_ingester.py
+++ b/ingester/tests/test_ingester.py
@@ -14,7 +14,7 @@ import minio
 import pytest
 from minio.error import S3Error
 
-from run import delete, init, update
+from run import DEFAULT_INITIAL_MAXIMUM_LOAD, delete, init, update
 
 from .conftest import ACCESS_KEY, BUCKET, PREFIX, SECRET_KEY
 from .helpers import full_args, wait_until
@@ -218,6 +218,16 @@ def s3_client_empty(rustfs_endpoint: str) -> Iterator[minio.Minio]:
     client = _setup_fresh_bucket_client(rustfs_endpoint)
     yield client
     remove_bucket(client, BUCKET)
+
+
+def test_default_initial_maximum_load():
+    """DEFAULT_INITIAL_MAXIMUM_LOAD が複数 fluent-bit 運用のスケールに足る値であることを確認する。
+
+    デフォルト値 1000 は 10 台構成で単一運用と同等の約 8 時間のカバーを実現する値であり、
+    デフォルト 100 のままでは複数 fluent-bit 環境で初期取り込みのカバー範囲が
+    想定より短くなるため、この値が意図せず変更されないことを検証する。
+    """
+    assert DEFAULT_INITIAL_MAXIMUM_LOAD == 1000
 
 
 def test_init(s3_client, rustfs_endpoint, tmp_path):

--- a/systemd/kohaku.service
+++ b/systemd/kohaku.service
@@ -12,7 +12,7 @@ Type=oneshot
 # 実行ユーザー
 User=kohaku
 # 初回読み込み時の最大件数
-Environment=INITIAL_MAXIMUM_LOAD=100
+Environment=INITIAL_MAXIMUM_LOAD=1000
 # update 1 回あたりの最大読み込み件数
 Environment=UPDATE_MAXIMUM_LOAD=100
 # 環境変数を読み込むファイル


### PR DESCRIPTION
## 対応 issue

- issues/0004-change-initial-maximum-load-default-for-multi-fluent-bit.md

## 変更内容

- `ingester/src/run.py` の `DEFAULT_INITIAL_MAXIMUM_LOAD` を 100 から 1000 に変更し、選定根拠を定数直上のコメントに記載する
- `systemd/kohaku.service` の `Environment=INITIAL_MAXIMUM_LOAD` を 1000 に更新する
- `ingester/README.md` の実行例と `.env.common.template` のコメント値を 1000 に更新する
- デフォルト値 1000 を検証するテスト `test_default_initial_maximum_load` を追加する

## 検証

- 全テスト 24 件通過 (test_ingester.py / test_fluent_bit_rustfs_integration.py)
- ruff check / ruff format / ty 通過