### PR TITLE
0005 list_objects の全件メモリ展開をやめる

### DIFF
--- a/ingester/src/run.py
+++ b/ingester/src/run.py
@@ -1,13 +1,17 @@
 import argparse
+import bisect
 import datetime
+import heapq
 import os
 import shutil
 import stat
 import sys
+from collections.abc import Iterable, Iterator
 
 import duckdb
 import minio
 import yaml
+from minio.datatypes import Object
 from minio.error import S3Error
 
 
@@ -159,9 +163,9 @@ def init(args):
 def initialize_log_table(con, client, args, target):
     """対象テーブルを初回作成する。
 
-    list_objects は (last_modified, object_name) の降順で並ぶため、先頭側 initial_maximum_load
-    件 (新しい側) のみを取り込み、カーソルは全体最新オブジェクトに進める。対象オブジェクトが
-    無ければ何もしない。
+    keep_latest_objects は (last_modified, object_name) の降順上位 initial_maximum_load
+    件 (新しい側) のみを保持して返すため、 その件数分のみを取り込み、 カーソルは全体最新
+    オブジェクト (保持分の先頭) に進める。 対象オブジェクトが無ければ何もしない。
 
     initial_maximum_load を超える古い側は「古すぎるデータを取り込まない」ため意図的に
     取り込まない。 init は最新側だけを取り込み、 update は取りこぼしを避けるため古い側から
@@ -190,16 +194,18 @@ def initialize_log_table(con, client, args, target):
             "Delete DB file and its .wal, then run 'init' again."
         )
 
-    log_objects = list_objects(client, args.s3_bucket, f"{args.s3_prefix}/{target}/")
+    log_objects = keep_latest_objects(
+        iter_objects(client, args.s3_bucket, f"{args.s3_prefix}/{target}/"),
+        args.initial_maximum_load,
+    )
     if len(log_objects) == 0:
         print(f"No log found for {target} in {args.s3_bucket}.", file=sys.stderr)
         return
 
-    log_urls = get_target_urls(args.s3_bucket, log_objects[: args.initial_maximum_load])
+    log_urls = get_target_urls(args.s3_bucket, log_objects)
     con.begin()
     try:
         create_log_table(con, target, log_urls)
-        # log_objects は降順なので、先頭が全体の最新オブジェクト
         update_s3_objects_table(con, target, log_objects[0])
         con.commit()
     except Exception:
@@ -411,20 +417,76 @@ def update_s3_objects_table(con, log_type, obj):
     con.execute(UPSERT_S3_OBJECTS_SQL, (log_type, obj.object_name, obj.last_modified))
 
 
-def list_objects(client, bucket, prefix):
-    """指定 prefix 配下のオブジェクトを (last_modified, object_name) の降順で返す。
+def iter_objects(client: minio.Minio, bucket: str, prefix: str) -> Iterator[Object]:
+    """指定 prefix 配下のオブジェクトをページ単位で遅延取得するイテレータを返す。
 
-    戻り値の先頭が最新のオブジェクト、最後が最古のオブジェクトになる。
-    last_modified が同値の場合は object_name の辞書順降順で並ぶ
-    (is_after_s3_cursor のカーソル比較順序と一致させるため)。
+    MinIO SDK の list_objects は 1 リクエスト 1000 件のページを遅延取得する generator を
+    返す。 これをそのまま返し、 全件をメモリ展開しない。 呼び出し側は
+    keep_latest_objects / collect_update_targets で必要な分だけを保持する。
 
-    オブジェクトキーが時系列順とは限らない (UUID 等を含むケースがある) ため、
-    MinIO の start_after でカーソル以降を絞り込むのは取り逃しのリスクがあり使用しない。
+    全ページ走査 + 必要分のみ保持を採用する。 オブジェクトキーが時系列順とは限らない
+    (UUID 等を含むケースがある) ため、 MinIO の start_after でのカーソル絞り込みは
+    カーソル (last_modified, object_name) に変換できず取り漏れる。 日付 prefix
+    (Delimiter) での絞り込みも、 キーの日付がチャンク生成時刻由来で last_modified
+    (PUT 完了時刻) と独立するため、 日付境界跨ぎや retry による遅延 PUT で取り漏れる。
     """
-    objects = list(client.list_objects(bucket, prefix=prefix, recursive=True))
-    return sorted(
-        objects, key=lambda obj: (obj.last_modified, obj.object_name), reverse=True
+    return client.list_objects(bucket, prefix=prefix, recursive=True)
+
+
+def keep_latest_objects(objects: Iterable[Object], max_objects: int) -> list[Object]:
+    """オブジェクトのイテレータを走査し、 (last_modified, object_name) の降順で上位
+    max_objects 件のみを保持して返す。
+
+    メモリは O(max_objects) で、 戻り値の先頭が最新のオブジェクトになる。 max_objects
+    は 1 以上を前提とする (CLI の positive_int が保証する)。
+    """
+    return heapq.nlargest(
+        max_objects,
+        objects,
+        key=lambda obj: (obj.last_modified, obj.object_name),
     )
+
+
+def collect_update_targets(
+    objects: Iterable[Object],
+    cursor_key: tuple[datetime.datetime, str],
+    update_maximum_load: int,
+) -> tuple[list[Object], list[Object]]:
+    """1 回のページ走査で update 対象のオブジェクトを集める。
+
+    戻り値は (target_log_objects, same_last_modified_objects)。
+    - target_log_objects: カーソルより新しいオブジェクトのうち、 古い側
+      update_maximum_load 件を (last_modified, object_name) の昇順 (古い順) で並べた
+      リスト。 カーソルはバッチ内最新までしか進めないため、 新しい側は次回以降の
+      update で取り込む
+    - same_last_modified_objects: カーソルと同値の last_modified を持つオブジェクト
+      (カーソル行自身を除く) の全件。 カーソル通過後に同値の last_modified で現れた
+      オブジェクトを拾うための再走査対象で、 重複行は PK 制約 + ON CONFLICT DO NOTHING
+      で吸収される。 カーソルと同値かつ object_name が大きいオブジェクトは
+      target_log_objects にも属しうるが、 保持の重複はメモリ上界に影響しない
+
+    同値グループのサイズは S3 の last_modified の粒度に依存し、 上限を保証できない
+    (通常は小さいが、 同時刻 PUT が集中すると増大し得る)。
+
+    generator を 1 回の走査で消費し、 メモリに保持するのは上記の 2 集合のみ
+    (O(update_maximum_load + 同値グループサイズ))。
+    """
+    cursor_last_modified, cursor_object_name = cursor_key
+    # bisect.insort の key は挿入位置の探索にのみ使われ、 同値キーでもオブジェクト同士は
+    # 比較されない。
+    kept: list[Object] = []
+    same_last_modified_objects: list[Object] = []
+    for obj in objects:
+        if (
+            obj.last_modified == cursor_last_modified
+            and obj.object_name != cursor_object_name
+        ):
+            same_last_modified_objects.append(obj)
+        if is_after_s3_cursor((obj.last_modified, obj.object_name), cursor_key):
+            bisect.insort(kept, obj, key=lambda o: (o.last_modified, o.object_name))
+            if len(kept) > update_maximum_load:
+                kept.pop()
+    return kept, same_last_modified_objects
 
 
 def get_target_urls(bucket, objects):
@@ -671,42 +733,20 @@ def insert_log_from_s3(
     """s3_objects カーソルより新しい S3 オブジェクトを古い順にバッチで取り込む。
 
     update 経路の中心関数。 呼び出し側 (sync_log_for_update) は cursor_key is not None
-    を保証する前提 (cursor_key は (last_modified, object_name) の 2 タプル)。 list_objects
-    (降順) と is_after_s3_cursor でカーソル以降の対象オブジェクトを絞り込み、 末尾側
-    update_maximum_load 件 (古い側) を 1 回の update で取り込む。 カーソルはバッチ内最新
-    までしか進めないため、 update_maximum_load を超えた新しい側は次回以降の update で
-    is_after_s3_cursor が True 判定して順次取得する。
-
-    カーソルと同値の last_modified を持つオブジェクト (カーソル行自身を除く) は、
-    バッチ分割の対象外として毎回の update で全件取り込む (カーソル通過後に同値の
-    last_modified で現れたオブジェクトを拾うため。 重複行は PK 制約 + ON CONFLICT
-    DO NOTHING で吸収する)。
+    を保証する前提 (cursor_key は (last_modified, object_name) の 2 タプル)。
+    collect_update_targets がカーソル以降の対象オブジェクトを絞り込み、 古い側
+    update_maximum_load 件を 1 回の update で取り込む (対象の定義とカーソル進行の
+    規則は同関数の docstring を参照)。
 
     insert_log とカーソル更新は con.begin() / con.commit() で囲み、 途中失敗時は
     con.rollback() で「行 insert とカーソル更新」 を atomic に保つ (中途半端な状態で
     残さない)。
     """
-    log_objects = list_objects(client, bucket, f"{prefix}/{table_name}/")
-
-    cursor_last_modified, cursor_object_name = cursor_key
-    target_log_objects = [
-        obj
-        for obj in log_objects
-        if is_after_s3_cursor((obj.last_modified, obj.object_name), cursor_key)
-    ]
-    same_last_modified_objects = [
-        obj
-        for obj in log_objects
-        if obj.last_modified == cursor_last_modified
-        and obj.object_name != cursor_object_name
-    ]
-
-    # 長時間停止後に大量ファイルが蓄積したケースに備え、古い方からバッチで取り込む。
-    # 降順ソートされているため、末尾側 update_maximum_load 件が古い順のバッチになる。
-    # 同値グループはバッチ分割の対象外とする (カーソルと同値のオブジェクトは毎回全件
-    # 取り込み、 重複は PK で吸収する)。
-    if len(target_log_objects) > update_maximum_load:
-        target_log_objects = target_log_objects[-update_maximum_load:]
+    target_log_objects, same_last_modified_objects = collect_update_targets(
+        iter_objects(client, bucket, f"{prefix}/{table_name}/"),
+        cursor_key,
+        update_maximum_load,
+    )
 
     if len(target_log_objects) == 0 and len(same_last_modified_objects) == 0:
         return
@@ -720,8 +760,8 @@ def insert_log_from_s3(
         if same_urls:
             insert_log(con, table_name, same_urls)
         if target_log_objects:
-            # 先頭がこのバッチの最新
-            update_s3_objects_table(con, table_name, target_log_objects[0])
+            # target_log_objects は昇順 (古い順) なので、末尾がこのバッチの最新
+            update_s3_objects_table(con, table_name, target_log_objects[-1])
         con.commit()
     except Exception:
         # rollback が disk full 等で失敗すると元例外が __context__ に沈み、stderr には

--- a/ingester/tests/test_ingester.py
+++ b/ingester/tests/test_ingester.py
@@ -4,6 +4,7 @@ import io
 import json
 import os
 import sys
+import tracemalloc
 import uuid
 from collections.abc import Iterator, Sequence
 from types import SimpleNamespace
@@ -12,9 +13,17 @@ from typing import Any
 import duckdb
 import minio
 import pytest
+from minio.datatypes import Object
 from minio.error import S3Error
 
-from run import DEFAULT_INITIAL_MAXIMUM_LOAD, delete, init, update
+from run import (
+    DEFAULT_INITIAL_MAXIMUM_LOAD,
+    collect_update_targets,
+    delete,
+    init,
+    keep_latest_objects,
+    update,
+)
 
 from .conftest import ACCESS_KEY, BUCKET, PREFIX, SECRET_KEY
 from .helpers import full_args, wait_until
@@ -27,6 +36,10 @@ def data_path(s3_prefix: str, tag: str, directory: str) -> str:
     """S3 のデータパスを生成する。"""
     filename = f"{uuid.uuid4()}.gz"
     return f"{s3_prefix}/{tag}/{directory}/{filename}"
+
+
+def make_object(object_name: str, last_modified: datetime.datetime) -> Object:
+    return Object("test-bucket", object_name, last_modified, "etag", 10)
 
 
 def list_objects(
@@ -228,6 +241,169 @@ def test_default_initial_maximum_load():
     想定より短くなるため、この値が意図せず変更されないことを検証する。
     """
     assert DEFAULT_INITIAL_MAXIMUM_LOAD == 1000
+
+
+def test_keep_latest_objects_limits_memory():
+    """keep_latest_objects が上限件数しか保持せず、降順で返すことを確認する。
+
+    上限を超える数のオブジェクトを渡しても保持は上限件数に留まる (全件をメモリ展開
+    しない) ことを、先頭が最新になる降順とあわせて検証する。
+    """
+    now = datetime.datetime.now(datetime.UTC)
+    objects = [
+        make_object(f"{i}.gz", now - datetime.timedelta(minutes=i)) for i in range(1000)
+    ]
+
+    kept = keep_latest_objects(iter(objects), 10)
+
+    assert len(kept) == 10
+    assert [obj.object_name for obj in kept] == [f"{i}.gz" for i in range(10)]
+
+
+def test_keep_latest_objects_same_last_modified():
+    """last_modified が同値のオブジェクトが object_name の辞書順降順で並ぶことを確認する。
+
+    カーソル比較 (is_after_s3_cursor) のタプル辞書順と一致させるため、同値キーでは
+    object_name の辞書順で並ぶ必要がある。
+    """
+    now = datetime.datetime.now(datetime.UTC)
+    objects = [make_object(f"{i}.gz", now) for i in range(10)]
+
+    kept = keep_latest_objects(iter(objects), 5)
+
+    assert len(kept) == 5
+    assert [obj.object_name for obj in kept] == ["9.gz", "8.gz", "7.gz", "6.gz", "5.gz"]
+
+
+def test_keep_latest_objects_does_not_expand_all_objects():
+    """keep_latest_objects が全件をメモリ展開しないことを確認する。
+
+    全件を list 化してから切り詰める実装に退化するとピークメモリが全件分に膨らむ。
+    2 万件の入力でピークメモリが上限件数相当に留まることを tracemalloc で検証する
+    (全件展開では実験値で約 6 MB、 上限保持では数十 KB)。
+    """
+    now = datetime.datetime.now(datetime.UTC)
+    object_count = 20000
+
+    def generate_objects() -> Iterator[Object]:
+        for i in range(object_count):
+            yield make_object(f"{i}.gz", now - datetime.timedelta(minutes=i))
+
+    tracemalloc.start()
+    try:
+        kept = keep_latest_objects(generate_objects(), 10)
+        _, peak = tracemalloc.get_traced_memory()
+    finally:
+        tracemalloc.stop()
+
+    assert len(kept) == 10
+    # 全件を list 化する実装は 2 万件分で 1 MB を超えるため、 閾値 1 MB で退化を検出する
+    assert peak < 1024 * 1024
+
+
+def test_collect_update_targets_does_not_expand_all_objects():
+    """collect_update_targets が全件をメモリ展開しないことを確認する。
+
+    カーソルより新しいオブジェクトを大量に走査しても、 保持されるのは最古
+    update_maximum_load 件のみに留まることを tracemalloc で検証する (全件を list 化して
+    切り詰める実装に退化するとピークメモリが全件分に膨らむ)。
+    """
+    now = datetime.datetime.now(datetime.UTC)
+    cursor_key = (now, "cursor.gz")
+    object_count = 20000
+
+    def generate_objects() -> Iterator[Object]:
+        for i in range(object_count):
+            yield make_object(f"new-{i}.gz", now + datetime.timedelta(minutes=1 + i))
+
+    tracemalloc.start()
+    try:
+        target_log_objects, same_last_modified_objects = collect_update_targets(
+            generate_objects(), cursor_key, update_maximum_load=10
+        )
+        _, peak = tracemalloc.get_traced_memory()
+    finally:
+        tracemalloc.stop()
+
+    assert len(target_log_objects) == 10
+    assert same_last_modified_objects == []
+    # 全件を list 化する実装は 2 万件分で 1 MB を超えるため、 閾値 1 MB で退化を検出する
+    assert peak < 1024 * 1024
+
+
+def test_collect_update_targets_limits_memory():
+    """collect_update_targets が全件を保持せず、 target 側のみ上限内のオブジェクトを保持することを確認する。
+
+    カーソルより古い多数のオブジェクトとカーソルより新しい多数のオブジェクト、 および
+    カーソルと同値の last_modified のオブジェクトを混在させ、 target 側の保持する
+    オブジェクト数が上限を超えないこと (同値グループは設計上全件保持) を検証する。
+    """
+    now = datetime.datetime.now(datetime.UTC)
+    cursor_key = (now, "cursor.gz")
+    # カーソルより古い多数のオブジェクト (update の取り込み対象外)
+    older = [
+        make_object(f"older-{i}.gz", now - datetime.timedelta(minutes=60 + i))
+        for i in range(5000)
+    ]
+    # カーソルより新しい多数のオブジェクト (うち古い側 update_maximum_load 件のみ保持)
+    newer = [
+        make_object(f"newer-{i}.gz", now + datetime.timedelta(minutes=1 + i))
+        for i in range(30)
+    ]
+    # カーソルと同値の last_modified のオブジェクト (全件保持)
+    same = [make_object(f"same-{i}.gz", now) for i in range(5)]
+    # カーソル行自身 (same にも target にも属さない)
+    cursor_object = make_object("cursor.gz", now)
+    # カーソルと同値かつ辞書順がカーソルより小さいオブジェクト (same のみに属する)
+    same_older_name = make_object("a-same.gz", now)
+
+    target_log_objects, same_last_modified_objects = collect_update_targets(
+        iter(older + newer + same + [cursor_object, same_older_name]),
+        cursor_key,
+        update_maximum_load=10,
+    )
+
+    # 古い側 10 件のみが昇順 (古い順) で保持される。 カーソルと同値の last_modified の
+    # オブジェクトはカーソルより新しいため target にも属する
+    assert [obj.object_name for obj in target_log_objects] == [
+        "same-0.gz",
+        "same-1.gz",
+        "same-2.gz",
+        "same-3.gz",
+        "same-4.gz",
+        "newer-0.gz",
+        "newer-1.gz",
+        "newer-2.gz",
+        "newer-3.gz",
+        "newer-4.gz",
+    ]
+    # カーソルと同値の last_modified のオブジェクトは全件保持される。 カーソル行自身
+    # (cursor.gz) は除外され、 辞書順がカーソルより小さい a-same.gz も含まれる
+    assert [obj.object_name for obj in same_last_modified_objects] == [
+        "same-0.gz",
+        "same-1.gz",
+        "same-2.gz",
+        "same-3.gz",
+        "same-4.gz",
+        "a-same.gz",
+    ]
+
+
+def test_collect_update_targets_no_candidate():
+    """カーソルより新しいオブジェクトも同値グループも無い場合に空の 2 集合を返すことを確認する。"""
+    now = datetime.datetime.now(datetime.UTC)
+    cursor_key = (now, "cursor.gz")
+    older = [
+        make_object(f"older-{i}.gz", now - datetime.timedelta(minutes=60 + i))
+        for i in range(100)
+    ]
+
+    target_log_objects, same_last_modified_objects = collect_update_targets(
+        iter(older), cursor_key, update_maximum_load=10
+    )
+
+    assert target_log_objects == []
+    assert same_last_modified_objects == []
 
 
 def test_init(s3_client, rustfs_endpoint, tmp_path):
@@ -909,6 +1085,7 @@ def test_update_maximum_load_splits_batches(s3_client, rustfs_endpoint, tmp_path
         new_lines = data.readlines()[:5]
     assert len(new_lines) == 5
 
+    new_s3_paths = []
     for line in new_lines:
         # 既存行をそのまま再 put すると natural key の PK で重複吸収されるため、
         # connection_id を変更して一意な行として put する
@@ -917,6 +1094,7 @@ def test_update_maximum_load_splits_batches(s3_client, rustfs_endpoint, tmp_path
         now = datetime.datetime.now(datetime.UTC)
         directory = now.strftime("%Y/%m/%d")
         s3_path = data_path(PREFIX, "rtc_stats", directory)
+        new_s3_paths.append(s3_path)
         compressed_log_data = gzip.compress(json.dumps(parsed_log).encode("utf-8"))
         s3_client.put_object(
             BUCKET,
@@ -933,6 +1111,28 @@ def test_update_maximum_load_splits_batches(s3_client, rustfs_endpoint, tmp_path
     # 1 回目: 2 件取り込まれること
     update(batch_args)
     assert fetch_rtc_stats_count() == initial_count + 2
+
+    # カーソルがバッチ内最新 (古い順 2 件のうち新しい側) に進むことを確認する。
+    # バッチ内最古に進む実装に退化すると、この検証で検出される。
+    # 期待カーソルは S3 上の実 last_modified から求める (put 順とは独立)
+    new_objects = [
+        obj
+        for obj in s3_client.list_objects(
+            BUCKET, prefix=f"{PREFIX}/rtc_stats/", recursive=True
+        )
+        if obj.object_name in new_s3_paths
+    ]
+    assert len(new_objects) == 5
+    expected_cursor = sorted(
+        new_objects, key=lambda obj: (obj.last_modified, obj.object_name)
+    )[1]
+    with duckdb.connect(duckdb_filepath) as con:
+        con.execute(
+            "SELECT object_name, last_modified FROM s3_objects WHERE type='rtc_stats'"
+        )
+        cursor = con.fetchone()
+    assert cursor is not None
+    assert cursor == (expected_cursor.object_name, expected_cursor.last_modified)
 
     # 2 回目: さらに 2 件取り込まれて合計 4 件追加
     update(batch_args)
@@ -952,7 +1152,7 @@ def test_update_maximum_load_one_takes_single_object_per_call(
 ):
     """update_maximum_load=1 (positive_int の最小値) で 1 回あたり 1 件ずつ取り込むことを確認する。
 
-    target_log_objects[-args.update_maximum_load :] のスライスが [-1:] になる境界値で、
+    collect_update_targets が保持する最古側 1 件のみを 1 回の update で取り込む境界値で、
     残件が複数あっても 1 件だけ取り込み、複数回呼び出しで取り込み切ることを確認する。
     """
     duckdb_filepath = str(tmp_path / "duck.db")

--- a/ingester/tests/test_run_unit.py
+++ b/ingester/tests/test_run_unit.py
@@ -549,7 +549,7 @@ def test_initialize_log_table_rejects_silent_gap_state(tmp_path):
     「テーブルはあるがカーソル行が無い状態」 をコード側で拒否することを担保する。
     この状態で処理を続けると、 create_log_table がスキップされる一方でカーソルだけが進み、
     過去オブジェクトが取り込まれない。 client には None を渡してもガードが早期に走るため
-    list_objects まで到達しない。
+    iter_objects まで到達しない。
     到達してしまうリグレッションは AttributeError で顕在化する。
     """
     db_path = tmp_path / "silent_gap.db"


### PR DESCRIPTION
## 概要

list_objects が S3 の全オブジェクトを一度にメモリ展開してソートするため、数十万オブジェクトで OOM になる。SDK の generator をそのまま返し、呼び出し側で必要な分だけを保持する方式に変更する。

## 変更内容

- `iter_objects` を新設し、 MinIO SDK の generator をそのまま返す (全件をメモリ展開しない)
- `keep_latest_objects` を新設し、 降順上位 N 件のみ保持する (init 経路)
- `collect_update_targets` を新設し、 最古 N 件とカーソル同値グループを 1 回の走査で収集する (update 経路)
- `initialize_log_table` / `insert_log_from_s3` を上記ヘルパー使用に変更する
- メモリ上界を検証する tracemalloc テストと、 カーソル進行の直接検証を追加する

## 完了条件

- [x] list_objects とその呼び出し経路が全件をメモリ展開しないことを検証するテストが追加され、通過する (init 経路: 先頭 initial_maximum_load 件のみ保持、 update 経路: 保持数が上限を超えないことの両方を検証)
- [x] 既存の統合テストが引き続き通過する (全 116 テスト通過)
- [x] 実装方針 (案 2) の選定理由と、 見送った案 (案 1・案 3) の却下理由が docstring に残る

## 関連 issue

- issues/0005-fix-list-objects-pagination.md